### PR TITLE
Fix for `StackoverFlowError`

### DIFF
--- a/test/test_mcmcchains.jl
+++ b/test/test_mcmcchains.jl
@@ -284,6 +284,12 @@ end
         @test attrs isa Dict
         @test attrs["inference_library"] == "MyLib"
     end
+
+    @testset "large number of variables" begin
+        num_vars = 1_000;
+        chn = Chains(randn(100, num_vars, 1), [Symbol("x[$i]") for i = 1:num_vars])
+        @test haskey(from_mcmcchains(chn).posterior, :x)
+    end
 end
 
 @testset "convert_to_dataset(::MCMCChains.Chains)" begin


### PR DESCRIPTION
On `#master`:

``` julia
julia> using MCMCChains, ArviZ

julia> num_vars = 1_000;

julia> chn = Chains(randn(100, num_vars, 1), [Symbol("x[$i]") for i = 1:num_vars]);

julia> @time from_mcmcchains(chn) # (×) `StackOverflowError` after quite a while...
```

(I couldn't actually reproduce the error; it just froze for ages :sweat_smile:)

In this PR:

``` julia
julia> using MCMCChains, ArviZ

julia> num_vars = 1_000;

julia> chn = Chains(randn(100, num_vars, 1), [Symbol("x[$i]") for i = 1:num_vars]);

julia> @time from_mcmcchains(chn) # (✓) Works!
  9.739639 seconds (22.51 M allocations: 1.699 GiB, 4.52% gc time)
InferenceData with groups:
        > posterior
```

``` julia
julia> versioninfo()
Julia Version 1.6.5
Commit 9058264a69 (2021-12-19 12:30 UTC)
Platform Info:
  OS: Linux (x86_64-pc-linux-gnu)
  CPU: Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-11.0.1 (ORCJIT, skylake)
```